### PR TITLE
update dependencies to use new source for polyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(source, sourceMap) {
 
         // append require()s with absoluted paths to neccessary polyfills
         polyfills.forEach(function(polyfill) {
-            inject += 'require(' + JSON.stringify(require.resolve('polyfill/source/' + polyfill)) + ');';
+            inject += 'require(' + JSON.stringify(require.resolve('polyfill-service/polyfills/' + polyfill + '/polyfill')) + ');';
             inject += '\n';
         });
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "source-map": "^0.1.39"
   },
   "dependencies": {
-    "autopolyfiller": "^1.3.0",
-    "polyfill": "git://github.com/jonathantneal/polyfill.git"
+    "autopolyfiller": "^1.6.0",
+    "polyfill-service": "1.3.0"
   },
   "devDependencies": {
     "eslint": "^0.8.2",


### PR DESCRIPTION
should resolve issue #1 and #6 

npm install still fails due to: https://github.com/Financial-Times/polyfill-service/issues/331 so I assume we need to wait until polyfill-service 1.3.0 is out