### PR TITLE
Fixed call autopolyfiller

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function(source, sourceMap) {
     // array of browsers
     var browsers = query.browsers || [];
     // array of polyfills names
-    var polyfills = autopolyfiller.apply(autopolyfiller, browsers).add(source).polyfills;
+    var polyfills = autopolyfiller(browsers).add(source).polyfills;
 
     if (this.cacheable) {
         this.cacheable();


### PR DESCRIPTION
Hello!

I have a problem with version `0.3.2`.
Webpack throwing an error:
```
Module build failed: TypeError: Function.prototype.apply: Arguments list has wrong type
        at Object.module.exports (.../node_modules/autopolyfiller-loader/index.js:12:36)
```

Changes from this pull request solved this error.